### PR TITLE
Fix SVG for Light Mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -66,6 +66,6 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
   svg {
-    fill: #1a1a1a;
+    color: #1a1a1a;
   }
 }


### PR DESCRIPTION
### Purpose:
This pull request resolves a styling issue that caused the SVG to not appear correctly in light mode.

### Changes:

- Modify SVG styling from `fill` to `color` property to ensure it works as intended in light mode.

### Testing:

- Verified the SVG displays correctly in light mode.